### PR TITLE
LSRD-565 "Modify L-LDOPE Toolkit unpack_oli_qa to handle LinearUnitsG…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # landsat-ldope-tools
-#summary Version 1.2.0 of the Landsat LDOPE Toolkit.
-== Landsat-LDOPE-Tools Version 1.2.0 Release Notes ==
+#summary Version 1.3.0 of the Landsat LDOPE Toolkit.
+== Landsat-LDOPE-Tools Version 1.3.0 Release Notes ==
 Release Date: March 2017
 
 ### Downloads
@@ -8,7 +8,7 @@ landsat-ldope-tools source code
 
     git clone https://github.com/USGS-EROS/landsat-ldope-tools.git
 
-See git tag [lldope_v1.2.0]
+See git tag [lldope_v1.3.0]
 
 ### Dependencies
   * GCTP libraries (obtained from the GCTP directory in the HDF-EOS2 source code)
@@ -67,6 +67,9 @@ https://landsat.usgs.gov/lldopetool
 The L-LDOPE User Guide is available at https://landsat.usgs.gov/sites/default/files/documents/lldope_tool_userguide.pdf
 
 ## Release Notes
-  * Added the unpack_collection_qa tool to support the collection-era Landsat 
-    QA band format.  This tool is similar to unpack_oli_qa.  It supports 
-    Landsat 4, 5, 7, and 8 inputs.
+  * Updated the unpack_oli_qa and unpack_collection_qa tools to read linear 
+    units from GeoTIFF tag ProjLinearUnitsGeoKey if it is available and 
+    GeogLinearUnitsGeoKey is not available
+  * Updated the unpack_oli_qa and unpack_collection_qa tools to be able to 
+    read tiled GeoTIFF files.  The outputs will not be tiled
+ 

--- a/src/unpack_collection_bits.c
+++ b/src/unpack_collection_bits.c
@@ -626,7 +626,7 @@ short unpack_bits
     bool tiled;              /* image is in Geotiff tiled format */
     int i;                   /* looping variable */
     int line, samp;          /* current line and sample to be processed */
-    int tile_line, tile_samp; /* current tile line and sample to be processed */
+    int tile_line;           /* current tile line to be processed */
     int line_offset;         /* Offset to reach start of current scan line */
     uint16 bitspersample;    /* bits per sample in input tiff image */
     uint16 sampleformat;     /* data type of input tiff image */
@@ -642,7 +642,7 @@ short unpack_bits
     tdata_t tile_buf=NULL;   /* Tiled QA band from the OLI file */
     uint16 *tile_values=NULL; /* Values of pixels from tile */
     int qa_line;             /* Line location of tile pixel in qa_buf */
-    int qa_samp;             /* Sample location of tile pixel in qa_buf */
+    int samples_to_copy = 0; /* The number of samples to copy to the buffer */
     uint16 proj_linear_units; /* geokey for the proj linear units (PS proj) */
     double proj_parms[15];   /* projection parameters (PS proj) */
     double tie_points[6];    /* corner point information */
@@ -906,29 +906,29 @@ short unpack_bits
                     qa_line = line + tile_line;
 
                     /* Tile sizes might not divide evenly into the image
-                       size.  Ignore parts of the last tile in a row
+                       size.  Ignore parts of the last tile in a column 
                        that go outside the image boundaries */
                     if (qa_line >= nlines)
                     {
                         continue;
                     }
 
-                    for (tile_samp = 0; tile_samp < tile_width; tile_samp++)
+                    /* Tile sizes might not divide evenly into the image size.
+                       Ignore parts of the last tile in a row that go outside
+                       the image boundaries */
+                    if (samp + tile_width > nsamps)
                     {
-                        qa_samp = samp + tile_samp;
-
-                        /* Tile sizes might not divide evenly into the image
-                           size.  Ignore parts of the last tile in a column
-                           that go outside the image boundaries */
-                        if (qa_samp >= nsamps)
-                        {
-                            continue;
-                        }
-
-                        /* Put the tile pixel in its spot of the image buffer */
-                        qa_buf[qa_line * nsamps + qa_samp]
-                            = tile_values[tile_line * tile_width + tile_samp];
+                        samples_to_copy = nsamps - samp;
                     }
+                    else
+                    {
+                        samples_to_copy = tile_width;
+                    }
+
+                    /* Put the tile line in its spot of the image buffer */
+                    memcpy(&qa_buf[qa_line * nsamps + samp],
+                           &tile_values[tile_line * tile_width],
+                           samples_to_copy * sizeof(uint16));
                 }
             }
         }
@@ -1225,7 +1225,7 @@ short unpack_combine_bits
     uint32 tile_length;      /* length of each tile (if tiled) */
     bool tiled;              /* image is in Geotiff tiled format */
     int line, samp;          /* current line and sample to be processed */
-    int tile_line, tile_samp; /* current tile line and sample to be processed */
+    int tile_line;           /* current tile line to be processed */
     int line_offset;         /* Offset to reach start of current scan line */
     uint16 bitspersample;    /* bits per sample in input tiff image */
     uint16 sampleformat;     /* data type of input tiff image */
@@ -1241,7 +1241,7 @@ short unpack_combine_bits
     tdata_t tile_buf=NULL;   /* Tiled QA band from the OLI file */
     uint16 *tile_values=NULL; /* Values of pixels from tile */
     int qa_line;             /* Line location of tile pixel in qa_buf */
-    int qa_samp;             /* Sample location of tile pixel in qa_buf */
+    int samples_to_copy = 0; /* The number of samples to copy to the buffer */
     uint16 proj_linear_units; /* geokey for the proj linear units (PS proj) */
     double proj_parms[15];   /* projection parameters (PS proj) */
     double tie_points[6];    /* corner point information */
@@ -1368,29 +1368,29 @@ short unpack_combine_bits
                     qa_line = line + tile_line;
 
                     /* Tile sizes might not divide evenly into the image
-                       size.  Ignore parts of the last tile in a row
+                       size.  Ignore parts of the last tile in a column
                        that go outside the image boundaries */
                     if (qa_line >= nlines)
                     {
                         continue;
                     }
 
-                    for (tile_samp = 0; tile_samp < tile_width; tile_samp++)
+                    /* Tile sizes might not divide evenly into the image size.
+                       Ignore parts of the last tile in a row that go outside
+                       the image boundaries */
+                    if (samp + tile_width > nsamps)
                     {
-                        qa_samp = samp + tile_samp;
-
-                        /* Tile sizes might not divide evenly into the image
-                           size.  Ignore parts of the last tile in a column
-                           that go outside the image boundaries */
-                        if (qa_samp >= nsamps)
-                        {
-                            continue;
-                        }
-
-                        /* Put the tile pixel in its spot of the image buffer */
-                        qa_buf[qa_line * nsamps + qa_samp]
-                            = tile_values[tile_line * tile_width + tile_samp];
+                        samples_to_copy = nsamps - samp;
                     }
+                    else
+                    {
+                        samples_to_copy = tile_width;
+                    }
+
+                    /* Put the tile line in its spot of the image buffer */
+                    memcpy(&qa_buf[qa_line * nsamps + samp],
+                           &tile_values[tile_line * tile_width],
+                           samples_to_copy * sizeof(uint16));
                 }
             }
         }

--- a/src/unpack_collection_qa.h
+++ b/src/unpack_collection_qa.h
@@ -88,6 +88,9 @@ short read_attributes
     int *proj,         /* O: projection type */
     uint32 *nlines,    /* O: number of lines in tiff image */
     uint32 *nsamps,    /* O: number of samples in tiff image */
+    uint32 *tile_width,     /* O: width of each tile (if tiled) */
+    uint32 *tile_length,    /* O: length of each tile (if tiled) */
+    bool *tiled,            /* O: Image is in GeoTiff tiled format */
     uint16 *bitspersample,  /* O: bits per sample in tiff image */
     uint16 *sampleformat,   /* O: data type of tiff image */
     double tie_point[6],    /* O: corner tie points for projection [3] is ULx

--- a/src/unpack_oli_qa.h
+++ b/src/unpack_oli_qa.h
@@ -87,6 +87,9 @@ short read_attributes
     int *proj,         /* O: projection type */
     uint32 *nlines,    /* O: number of lines in tiff image */
     uint32 *nsamps,    /* O: number of samples in tiff image */
+    uint32 *tile_width,     /* O: width of each tile (if tiled) */
+    uint32 *tile_length,    /* O: length of each tile (if tiled) */
+    bool *tiled,            /* O: Image is in GeoTiff tiled format */
     uint16 *bitspersample,  /* O: bits per sample in tiff image */
     uint16 *sampleformat,   /* O: data type of tiff image */
     double tie_point[6],    /* O: corner tie points for projection [3] is ULx


### PR DESCRIPTION
…eoKey

scenarios".  Add the ability to read inputs with ProjLinearUnitsGeoKey but
without GeogLinearUnitsGeoKey.  Also, it was found that the same set of
scenes were tiled, so also added the ability to read inputs in GeoTiff tiled
format (the outputs in this case are still untiled).  This applies to
unpack_oli_qa and unpack_collection_qa.  We didn't have actual collection
inputs with the problem, so I simulated it using gdal_translate -co "TILED=yes".